### PR TITLE
feat: support preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,18 @@ yarn add --global rag-crawler
 Usage: rag-crawler [options] <startUrl> [outPath]
 
 Arguments:
-  startUrl                    The URL to start crawling from. [required]
-  outPath                     The output path. If omitted, output to stdout
+  startUrl                     The URL to start crawling from. [required]
+  outPath                      The output path. If omitted, output to stdout
 
 Options:
-  --extract <css-selector>    Extract specific content using a CSS selector
-  --max-connections <number>  Maximum concurrent connections (default: 5)
-  -e, --exclude <names>       Comma-separated list of path names to exclude
-  --no-markdown               Don't convert crawled HTML to Markdown
-  --no-log                    Disable logging
-  -V, --version               output the version number
-  -h, --help                  display help for command
+  --preset <value>             Use predefined crawl rules (default: "auto")
+  -c, --max-connections <int>  Maximum concurrent connections to crawl
+  -e, --exclude <values>       Comma-separated list of path names to exclude
+  --extract <selector>         Extract specific content using a CSS selector
+  --no-markdown                Don't convert crawled HTML to Markdown
+  --no-log                     Disable logging
+  -V, --version                output the version number
+  -h, --help                   display help for command
 ```
 
 **Output to stdout**
@@ -68,11 +69,6 @@ pages
     └── languages.md
 ```
 
-**Crawler github wiki**
-```
-$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --exclude _history --extract '#wiki-body'
-```
-
 **Crawler markdown files from github repo**
 
 ```
@@ -80,6 +76,61 @@ $ rag-crawler https://github.com/sigoden/mynotes/tree/main/src/languages/ knowle
 ```
 
 > Many documentation sites host their source Markdown files on GitHub. The crawler has been optimized to crawl these files directly from GitHub.
+
+## Preset
+
+A preset consists of predefined crawl rules. You can review the predefined presets at [./src/preset.ts](./src/preset.ts).
+
+### Why Use Presets?
+
+Let's use GitHub Wiki as an example. To enhance scraping quality, we need to configure both `--exclude` and `--extract`.
+
+```
+$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --exclude _history --extract '#wiki-body'
+```
+
+Since all GitHub Wiki websites share these crawl options, we can define a preset for reusability.
+
+```js
+{
+  name: "github-wiki",
+  test: "github.com/([^/]+)/([^/]+)/wiki",
+  options: {
+    exclude: ["_history"],
+    extract: "#wiki-body",
+  },
+}
+```
+
+This allows for a simplified command:
+
+```
+$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --preset github-wiki
+// or
+$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --preset auto
+// or
+$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json # The default value of '--preset' is 'auto'
+```
+
+> When the preset is set to `auto`, rag-crawler will automatically determine the appropriate preset. It does this by checking if the `startUrl` matches the `test` regex.
+
+### Custom Presets
+
+You can add custom presets by editing the `$HOME/.rag-crawler.json` file:
+
+```json
+[
+  {
+    "name": "github-wiki",
+    "test": "github.com/([^/]+)/([^/]+)/wiki",
+    "options": {
+      "exclude": ["_history"],
+      "extract": "#wiki-body"
+    }
+  },
+  ...
+]
+```
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ $ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --preset github-w
 // or
 $ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --preset auto
 // or
-$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json # The default value of '--preset' is 'auto'
+$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json # `--reset` default to 'auto'
 ```
 
 > When the preset is set to `auto`, rag-crawler will automatically determine the appropriate preset. It does this by checking if the `startUrl` matches the `test` regex.

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,12 +4,26 @@ import { program } from "commander";
 import { RequestInit } from "node-fetch";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import path from "node:path";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  fstat,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 
 import { CrawlOptions, Page, crawlPage } from "./index.js";
+import PRESET_LIST, { Preset } from "./preset.js";
 
 async function main() {
-  const { extract, maxConnections, markdown, log, exclude } = program.opts();
+  const {
+    preset,
+    maxConnections,
+    exclude = [],
+    extract,
+    markdown,
+    log,
+  } = program.opts();
   const [startUrl, outPath] = program.args;
   const fetchOptions: RequestInit = {
     headers: {
@@ -23,14 +37,28 @@ async function main() {
   }
   let options: Partial<CrawlOptions> = {
     maxConnections,
+    exclude,
     extract,
-    exclude: exclude || [],
     toMarkdown: !!markdown,
     logEnabled: !!log,
     fetchOptions,
   };
+  applyPreset(preset, startUrl, options);
+  if (!options.maxConnections) {
+    options.maxConnections = 5;
+  }
   if (!outPath) {
     options.logEnabled = false;
+  }
+  if (options.logEnabled) {
+    console.log(`🕸️  Starting crawl of ${startUrl}`);
+    console.log(
+      `⚙️  maxConnections=${
+        options.maxConnections
+      } exclude='${options.exclude.join(",")}' extract='${
+        options.extract || ""
+      }' toMarkdown=${options.toMarkdown}`,
+    );
   }
   const pages: Page[] = [];
   for await (const page of crawlPage(startUrl, options)) {
@@ -58,24 +86,75 @@ async function main() {
   }
 }
 
+function applyPreset(
+  preset: string,
+  startUrl: string,
+  options: Partial<CrawlOptions>,
+) {
+  let presetOptions: Preset["options"] | undefined;
+  let presets = loadPresets();
+  if (preset === "auto") {
+    presetOptions = presets.find((p) => new RegExp(p.test).test(startUrl))
+      ?.options;
+  } else if (preset) {
+    presetOptions = presets.find((p) => p.name === preset)?.options;
+  }
+  if (presetOptions) {
+    if (presetOptions.maxConnections && !options.maxConnections) {
+      options.maxConnections = presetOptions.maxConnections;
+    }
+    if (presetOptions.exclude?.length && !options.exclude?.length) {
+      options.exclude = presetOptions.exclude;
+    }
+    if (presetOptions.extract && !options.extract) {
+      options.extract = presetOptions.extract;
+    }
+    if (
+      presetOptions.headers &&
+      Object.getPrototypeOf(presetOptions.headers) === Object.prototype
+    ) {
+      options.fetchOptions.headers = {
+        ...options.fetchOptions.headers,
+        ...presetOptions.headers,
+      };
+    }
+  }
+}
+
+function loadPresets(): Preset[] {
+  const homeDir = process.env.HOME;
+  const filePath = path.join(homeDir, ".rag-crawler.json");
+  try {
+    const data = readFileSync(filePath, "utf-8");
+
+    const jsonData = JSON.parse(data);
+
+    if (Array.isArray(jsonData)) {
+      return [...jsonData, ...PRESET_LIST];
+    }
+  } catch {
+    return PRESET_LIST;
+  }
+}
+
 program
   .name("rag-crawler")
   .argument("<startUrl>", "The URL to start crawling from. [required]")
   .argument("[outPath]", "The output path. If omitted, output to stdout")
+  .option("--preset <value>", "Use predefined crawl rules", "auto")
   .option(
-    "--extract <css-selector>",
-    "Extract specific content using a CSS selector"
-  )
-  .option(
-    "--max-connections <number>",
-    "Maximum concurrent connections",
+    "-c, --max-connections <int>",
+    "Maximum concurrent connections to crawl",
     parseInt,
-    5,
   )
   .option(
-    "-e, --exclude <names>",
+    "-e, --exclude <values>",
     "Comma-separated list of path names to exclude",
     (value: string) => value.split(","),
+  )
+  .option(
+    "--extract <selector>",
+    "Extract specific content using a CSS selector",
   )
   .option("--no-markdown", "Don't convert crawled HTML to Markdown")
   .option("--no-log", "Disable logging")
@@ -85,5 +164,5 @@ program.parse();
 
 main().catch((err) => {
   console.error(err);
-  process.exit(1)
+  process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export interface CrawlOptions {
   /**
    * Extract specific content using CSS selector
    */
-  extract?: string,
+  extract?: string;
   /**
    * Whether to convert crawled html to markdown.
    */
@@ -48,7 +48,7 @@ export interface CrawlOptions {
 }
 
 const IS_GITHUB_REPO =
-  /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/tree\/([^\/]+)/;
+  /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/tree\/([^/]+)/;
 
 export async function* crawlPage(
   startUrl: string,
@@ -72,7 +72,6 @@ export async function* crawlPage(
 
   if (IS_GITHUB_REPO.test(startUrl)) {
     paths = await crawlGithubRepo(startUrlObj);
-    options.exclude.push("changelog");
   }
 
   let index = 0;
@@ -102,7 +101,7 @@ export async function* crawlPage(
     index += batch.length;
   }
   if (options.logEnabled) {
-    console.log("Crawl completed");
+    console.log("✨ Crawl completed");
   }
 }
 
@@ -155,7 +154,7 @@ async function getLinksFromUrl(
   const location = new URL(path, startUrl).toString();
 
   if (options.logEnabled) {
-    console.log(`Crawl ${location}`);
+    console.log(`🚀 Crawling ${location}`);
   }
 
   let html = "";
@@ -201,13 +200,13 @@ async function getLinksFromUrl(
 
   let text = html;
   if (options.extract) {
-    text = $(options.extract)?.html()
+    text = $(options.extract)?.html();
     if (!text) {
       return {
         path,
         text: "",
-        links: []
-      }
+        links: [],
+      };
     }
   }
   if (options.toMarkdown) {

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,0 +1,30 @@
+const PRESET_LIST: Preset[] = [
+  {
+    name: "github-repo",
+    test: "github.com/([^/]+)/([^/]+)/tree/([^/]+)",
+    options: {
+      exclude: ["changelog", "changes", "license"],
+    },
+  },
+  {
+    name: "github-wiki",
+    test: "github.com/([^/]+)/([^/]+)/wiki",
+    options: {
+      exclude: ["_history"],
+      extract: "#wiki-body",
+    },
+  },
+];
+
+export interface Preset {
+  name: string;
+  test: string;
+  options: {
+    exclude?: string[];
+    extract?: string;
+    maxConnections?: number;
+    headers?: Record<string, string>;
+  };
+}
+
+export default PRESET_LIST;


### PR DESCRIPTION
## Preset

A preset consists of predefined crawl rules. You can review the predefined presets at [./src/preset.ts](./src/preset.ts).

### Why Use Presets?

Let's use GitHub Wiki as an example. To enhance scraping quality, we need to configure both `--exclude` and `--extract`.

```
$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --exclude _history --extract '#wiki-body'
```

Since all GitHub Wiki websites share these crawl options, we can define a preset for reusability.

```js
{
  name: "github-wiki",
  test: "github.com/([^/]+)/([^/]+)/wiki",
  options: {
    exclude: ["_history"],
    extract: "#wiki-body",
  },
}
```

This allows for a simplified command:

```
$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --preset github-wiki
// or
$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json --preset auto
// or
$ rag-crawler https://github.com/sigoden/aichat/wiki wiki.json # The default value of '--preset' is 'auto'
```

> When the preset is set to `auto`, rag-crawler will automatically determine the appropriate preset. It does this by checking if the `startUrl` matches the `test` regex.

### Custom Presets

You can add custom presets by editing the `$HOME/.rag-crawler.json` file:

```json
[
  {
    "name": "github-wiki",
    "test": "github.com/([^/]+)/([^/]+)/wiki",
    "options": {
      "exclude": ["_history"],
      "extract": "#wiki-body"
    }
  },
  ...
]
```